### PR TITLE
Ability to configure roles and override the file if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## master - unreleased
 ### Changed
+### Added
+- `:override` option to `ConfigFor::Capistrano::Task` to upload file every time
 
 ## 0.3.0 - 2016-11-09
 ### Changed

--- a/lib/config_for/capistrano.rb
+++ b/lib/config_for/capistrano.rb
@@ -105,12 +105,12 @@ module ConfigFor
       # @param [String, Symbol] name name of this tasks and subtasks
       # @param &block gets evaluated before defining the tasks
       # @yieldparam [Task] task the task itself so you can modify it before it gets defined
-      def initialize(name, &block)
+      def initialize(name, options = {}, &block)
         @name = name
         @folder = 'config'
         @file = "#{name}.yml"
         @variable = "#{name}_yml".to_sym
-        @roles = :all
+        @roles = options.fetch(:roles, :all)
 
         yield(self) if block_given?
 

--- a/lib/config_for/capistrano.rb
+++ b/lib/config_for/capistrano.rb
@@ -25,6 +25,7 @@ module ConfigFor
       # @param [Pathname, String] path the path of the file to be uploaded
       # @param [Hash] options the options
       # @option options [Array<Symbol>,Symbol] :roles (:all) the roles of servers to apply to
+      # @option options [true,false] :override (false) upload file on every run
       # @yieldparam [Tempfile] file yields the tempfile so you generate the file to be uploaded
       def initialize(path, options = {}, &block)
         @path = path
@@ -105,6 +106,7 @@ module ConfigFor
       # Generates new tasks with for uploading #name
       # @param [String, Symbol] name name of this tasks and subtasks
       # @param &block gets evaluated before defining the tasks
+      # @option options [true,false] :override (false) upload file on every run
       # @yieldparam [Task] task the task itself so you can modify it before it gets defined
       def initialize(name, options = {}, &block)
         @name = name

--- a/lib/config_for/capistrano.rb
+++ b/lib/config_for/capistrano.rb
@@ -67,13 +67,14 @@ module ConfigFor
 
       def remote_file(task)
         target_roles = task.delete(:roles)
+        override = task.delete(:override)
 
         UploadTask.define_task(task) do |t|
           prerequisite_file = t.prerequisites.first
           file = shared_path.join(t.name).to_s.shellescape
 
           on roles(target_roles) do
-            if task.delete(:override) || !test("[ -f #{file} ]")
+            if override || !test("[ -f #{file} ]")
               info "Uploading #{prerequisite_file} to #{file}"
               upload! File.open(prerequisite_file), file
             end


### PR DESCRIPTION
Without this option the `*:upload` task will not touch the file if it already exists
To achieve that it was needed to invoke the `*:reset` before your deploy
Now the files are ensured to be up to date